### PR TITLE
update to 0.8.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
   build:
     - cmake !=3.19.0,!=3.19.1
     - {{ compiler('c') }}
-    - ninja
+    - ninja-base
 
 test:
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "aws-c-common" %}
-{% set version = "0.6.8" %}
+{% set version = "0.8.5" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://github.com/awslabs/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: 2997e851ed690a614507a43f4c393f45a198614d94da1660ecdf9b5a729535fc
+  sha256: 9a6b9026de9ad0c1aac2aadbbf83e331f8259d8a8d6ce2f59f2094040bba3e71
 
 build:
-  number: 1
+  number: 0
   run_exports:
     - {{ pin_subpackage("aws-c-common", max_pin="x.x.x") }}
   missing_dso_whitelist:
@@ -27,11 +27,13 @@ test:
     - test -f $PREFIX/lib/libaws-c-common${SHLIB_EXT}  # [unix]
     - test -f $PREFIX/include/aws/common/config.h  # [unix]
     - test -f $PREFIX/lib/cmake/AwsCFlags.cmake  # [unix]
+    - test -f $PREFIX/lib/cmake/AwsFindPackage.cmake  # [unix]
     # Check for the non-existence of -Werror in the CFLAGS
     - '! grep Werror $PREFIX/lib/cmake/AwsCFlags.cmake'  # [unix]
     - if not exist %PREFIX%\\Library\\bin\\aws-c-common.dll exit 1  # [win]
     - if not exist %PREFIX%\\Library\\include\\aws\\common\\config.h exit 1  # [win]
     - if not exist %PREFIX%\\Library\\lib\\cmake\\AwsCFlags.cmake exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\lib\\cmake\\AwsFindPackage.cmake exit 1  # [win]
 
 about:
   home: https://github.com/awslabs/aws-c-common


### PR DESCRIPTION
aws-c-common 0.8.5
Adding required cmake function
[jira](https://anaconda.atlassian.net/browse/PKG-3912)
[github](https://github.com/awslabs/aws-c-common/tree/v0.8.5)
dependency for aws-sdk-cpp 1.10.55 -> arrow-cpp 14.0.1 -> pyarrow 14.0.1  which would address CVE

