### PR TITLE
v0.11.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "aws-c-common" %}
-{% set version = "0.8.5" %}
+{% set version = "0.11.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/awslabs/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: 9a6b9026de9ad0c1aac2aadbbf83e331f8259d8a8d6ce2f59f2094040bba3e71
+  sha256: b442cc59f507fbe232c0ae433c836deff83330270a58fa13bf360562efda368a
 
 build:
   number: 0
@@ -26,14 +26,12 @@ test:
   commands:
     - test -f $PREFIX/lib/libaws-c-common${SHLIB_EXT}  # [unix]
     - test -f $PREFIX/include/aws/common/config.h  # [unix]
-    - test -f $PREFIX/lib/cmake/AwsCFlags.cmake  # [unix]
-    - test -f $PREFIX/lib/cmake/AwsFindPackage.cmake  # [unix]
-    # Check for the non-existence of -Werror in the CFLAGS
-    - '! grep Werror $PREFIX/lib/cmake/AwsCFlags.cmake'  # [unix]
+    - test -f $PREFIX/lib/cmake/aws-c-common/modules/AwsCFlags.cmake  # [unix]
+    - test -f $PREFIX/lib/cmake/aws-c-common/modules/AwsFindPackage.cmake  # [unix]
     - if not exist %PREFIX%\\Library\\bin\\aws-c-common.dll exit 1  # [win]
     - if not exist %PREFIX%\\Library\\include\\aws\\common\\config.h exit 1  # [win]
-    - if not exist %PREFIX%\\Library\\lib\\cmake\\AwsCFlags.cmake exit 1  # [win]
-    - if not exist %PREFIX%\\Library\\lib\\cmake\\AwsFindPackage.cmake exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\lib\\cmake\\aws-c-common\\modules\\AwsCFlags.cmake exit 1  # [win]
+    - if not exist %PREFIX%\\Library\\lib\\cmake\\aws-c-common\\modules\\AwsFindPackage.cmake exit 1  # [win]
 
 about:
   home: https://github.com/awslabs/aws-c-common


### PR DESCRIPTION
aws-c-common v0.11.1

**Destination channel:** defaults

### Links

- [PKG-7283](https://anaconda.atlassian.net/browse/PKG-7283) 
- [Upstream repository](https://github.com/awslabs/aws-c-common/tree/v0.11.1)
- [Upstream changelog/diff](https://github.com/awslabs/aws-c-common/compare/v0.8.5...v0.11.1)


### Explanation of changes:

- The first of many aws-* builds
- Bump version and sha. 
- Update cmake paths to match https://github.com/awslabs/aws-c-common/pull/1178 


[PKG-7283]: https://anaconda.atlassian.net/browse/PKG-7283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ