### PR TITLE
Update version to 0.12.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "aws-c-common" %}
-{% set version = "0.12.4" %}
+{% set version = "0.12.6" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/awslabs/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: 0b7705a4d115663c3f485d353a75ed86e37583157585e5825d851af634b57fe3
+  sha256: 138822ecdcaff1d702f37d4751f245847d088592724921cc6bf61c232b198d6b
   patches:
     - patches/0001-Explicitly-remove-Werror.patch
 


### PR DESCRIPTION
aws-c-common 0.12.6

**Destination channel:**  defaults

### Links

- [PKG-10902](https://anaconda.atlassian.net/browse/PKG-10902) 
- [Upstream repository](https://github.com/awslabs/aws-c-common/tree/v0.12.6)

### Explanation of changes:

- New version number


[PKG-10902]: https://anaconda.atlassian.net/browse/PKG-10902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ